### PR TITLE
Referencing undeclared variable

### DIFF
--- a/url.js
+++ b/url.js
@@ -145,7 +145,7 @@
 
         case 'scheme data':
           if ('?' == c) {
-            query = '?';
+            this._query = '?';
             state = 'query';
           } else if ('#' == c) {
             this._fragment = '#';


### PR DESCRIPTION
Having ? in href breaks Polymer in Safari
e.g) < a href="mailto:jpar225@gmail.com?subject=Greetings&body=Hello there" >
