### PR TITLE
Cast url parameter to String in new Url(url, base)

### DIFF
--- a/url.js
+++ b/url.js
@@ -481,10 +481,10 @@ Window.prototype.forceJURL = false;
     if (base !== undefined && !(base instanceof jURL))
       base = new jURL(String(base));
 
-    this._url = url;
+    this._url = '' + url;
     clear.call(this);
 
-    var input = url.replace(/^[ \t\r\n\f]+|[ \t\r\n\f]+$/g, '');
+    var input = this._url.replace(/^[ \t\r\n\f]+|[ \t\r\n\f]+$/g, '');
     // encoding = encoding || 'utf-8'
 
     parse.call(this, input, null, base);


### PR DESCRIPTION
Fix #31 

Be in sync with the behaviour of modern browsers where

new URL(undefined, 'https://example.com') == 'https://example.com/undefined'
new URL(null, 'https://example.com') == 'https://example.com/null'