### PR TITLE
support .hash = '' calls

### DIFF
--- a/url.js
+++ b/url.js
@@ -581,6 +581,10 @@ Window.prototype.forceJURL = false;
     set hash(hash) {
       if (this._isInvalid)
         return;
+      if(!hash) {
+        this._fragment = '';
+        return;
+      } 
       this._fragment = '#';
       if ('#' == hash[0])
         hash = hash.slice(1);


### PR DESCRIPTION
When calling `.hash = ''`, the hash (fragment) part should be cleared, including the `#` character.

Right now the `#` is added regardless of the value of the hash